### PR TITLE
Switch to image from https://github.com/Surnet/docker-wkhtmltopdf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,4 @@
-FROM node:8-alpine
-
-RUN apk add --update --no-cache \
-            xvfb \
-            libgcc \
-            libstdc++ \
-            libx11 \
-            glib \
-            libxrender \
-            libxext \
-            libintl \
-            libcrypto1.1 \
-            libssl1.1 \
-            ttf-opensans
-
-# We use a pre-compiled version of wkhtmltopdf because there are no Alpine binaries available on https://wkhtmltopdf.org/downloads.html
-# There is a version of wkhtml in alpine's git repository, but it is in the testing directory, so we don't want to reference that.
-# This binary's build steps were configured by https://github.com/alloylab/Docker-Alpine-wkhtmltopdf including qt patches
-COPY wkhtmltopdf /usr/bin/wkhtmltopdf
-ENV PATH "$PATH:/usr/bin/wkhtmltopdf"
-RUN chmod -R 777 /usr/bin/wkhtmltopdf
+FROM surnet/alpine-node-wkhtmltopdf:8.11.3-0.12.5-full-font
 
 COPY index.js .
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # html-pdf-export
-HTTP Service to convert HTML to PDF. This image is based on [werkspot/html2pdf](https://github.com/Werkspot/html2pdf).
+HTTP Service to convert HTML to PDF. Using image from https://github.com/Surnet/docker-wkhtmltopdf
 
 We used alpine linux instead of ubuntu to drasticly decrease the container size.
 


### PR DESCRIPTION
Probleem: libssl1.0 en libcrypto1.0 zijn niet meer beschikbaar in nieuwere alpine builds
En omdat de pre-compiled binary gebuild is met die libs kan niet makkelijk worden geupdate

- alpine heeft nu een build van wkhtmltopdf in de repos, maar dat is zonder qt patches. Daardoor werken een hoop dingen  niet
- De build image die gebruikt is voor de huidige binary die draait niet meer (en is ook al 5 jaar niet geupdate)
- Ze zijn bij wkhtmltopdf bezig een officiele alpine build toe te voegen, als dat klaar is kunnen we daar naar switchen


Voor nu:
- Er is een nieuwer build script, die ook meer gebruikt lijkt te worden: https://github.com/Surnet/docker-wkhtmltopdf

Deze PR:
- uses image from https://github.com/Surnet/docker-wkhtmltopdf
- Which means:
  - updates wkhtmltopodf from 0.12.4 to 0.12.5
  - Fixes depency issues (libssl & libcrypto: 1.0 vs 1.1)